### PR TITLE
Show active users for each switch in the admin list view.

### DIFF
--- a/hashbrown/admin.py
+++ b/hashbrown/admin.py
@@ -1,11 +1,15 @@
 from django.contrib import admin
+from django.utils.encoding import force_text
 
 from .models import Switch
 
 
 class SwitchAdmin(admin.ModelAdmin):
-    list_display = ('label', 'globally_active', 'description')
+    list_display = ('label', 'globally_active', 'active_for_users', 'description')
     list_editable = ('globally_active',)
+
+    def active_for_users(self, obj):
+        return u', '.join(force_text(user) for user in obj.users.all())
 
 
 admin.site.register(Switch, SwitchAdmin)


### PR DESCRIPTION
These changes make it easy to see if a switch is enabled for specific users in the Django admin list view.

I also want to change the admin switch detail edit view so that it prints the currently enabled users for a switch. The idea here would be to make it easier to edit the related users for a switch when you have thousands of user choices. But ignoring that for now.
