### PR TITLE
Avoid importing a model from __init__.py, for Django 1.9 compatibility.

### DIFF
--- a/hashbrown/utils.py
+++ b/hashbrown/utils.py
@@ -1,11 +1,12 @@
 from django.conf import settings
-from .models import Switch
 
 
 SETTINGS_KEY = 'HASHBROWN_SWITCH_DEFAULTS'
 
 
 def is_active(label, user=None):
+    from .models import Switch
+
     defaults = get_defaults()
 
     globally_active = defaults[label].get(


### PR DESCRIPTION
If `hashbrown` is in `INSTALLED_APPS`:

- Django imports `hashbrown/__init__.py`
- Which imports `hashbrown/utils.py`
- Which imports `hashbrown/models.py`
- Which defines a model

and Django 1.9+ screams this at you:

```
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

Easy solution. Tests pass with Django 1.9.12

(although not 1.10.x because of changes to template loader config — will raise a separate ticket for that)