### PR TITLE
Django 1.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 Yet another dead simple feature switching library for Django.
 
+Supports Django 1.8, 1.9 & 1.10.
 
 ## Installation
 

--- a/hashbrown/management/commands/switches.py
+++ b/hashbrown/management/commands/switches.py
@@ -1,5 +1,3 @@
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 from django.utils.six.moves import input
 

--- a/hashbrown/management/commands/switches.py
+++ b/hashbrown/management/commands/switches.py
@@ -10,20 +10,19 @@ from hashbrown.utils import SETTINGS_KEY, is_active, get_defaults
 class Command(BaseCommand):
     help = 'Creates / deletes feature switches in the database'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--delete',
             action='store_true',
             default=False,
             help='Delete switches in the database that are not in ' + SETTINGS_KEY,
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '--force',
             action='store_true',
             default=False,
             help='Delete switches without confirmation (implies --delete)',
-        ),
-    )
+        )
 
     def handle(self, *args, **kwargs):
         if kwargs['delete'] or kwargs['force']:

--- a/hashbrown/utils.py
+++ b/hashbrown/utils.py
@@ -1,11 +1,12 @@
 from django.conf import settings
-from .models import Switch
 
 
 SETTINGS_KEY = 'HASHBROWN_SWITCH_DEFAULTS'
 
 
 def is_active(label, user=None):
+    from .models import Switch
+
     defaults = get_defaults()
 
     globally_active = defaults[label].get(

--- a/runtests.py
+++ b/runtests.py
@@ -19,6 +19,12 @@ settings.configure(
       ),
       # Django 1.7 raises a warning if this isn't set. Pollutes test output.
       MIDDLEWARE_CLASSES = (),
+      TEMPLATES = [{
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {},
+      }],
 )
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*rnames):
 
 setup(
     name="django-hashbrown",
-    version="0.6.1",
+    version="0.7.0",
     author="Pablo Recio",
     author_email="pablo@potatolondon.com",
     description="Yet another dead simple feature switching library for Django.",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 # Requires tox>=1.8
 
 [tox]
-envlist = {py27,py34}-django{15,16,17}
+envlist = {py27,py34}-django{18,19,110}
 skip_missing_interpreters=True
 
 [testenv]
 commands = python runtests.py
 deps =
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11


### PR DESCRIPTION
A couple of fixes for Django 1.10 support.

Tests pass, at least, with 1.10.6.
