### PR TITLE
removed superfluous field in models

### DIFF
--- a/hashbrown/models.py
+++ b/hashbrown/models.py
@@ -11,7 +11,7 @@ class Switch(models.Model):
     globally_active = models.BooleanField(default=False)
 
     users = models.ManyToManyField(
-        User, null=True, related_name='available_switches', blank=True)
+        User, related_name='available_switches', blank=True)
 
     class Meta:
         verbose_name_plural = u'switches'


### PR DESCRIPTION
Null=True is ignored by Django, but throws a warning.

In an effort to improve error visibility in Defjam, we are trying to remove noise from the logs.

Explanation here:
https://stackoverflow.com/questions/18243039/migrating-manytomanyfield-to-null-true-blank-true-isnt-recognized/18244527